### PR TITLE
Fix running buffet without options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ settings.yml
 working-directory
 test
 data/
+/.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buffet-gem (1.1)
+    buffet-gem (1.1.1)
       colorize
       wopen3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buffet-gem (1.1.1)
+    buffet-gem (1.1.2)
       colorize
       wopen3
 

--- a/lib/buffet/cli.rb
+++ b/lib/buffet/cli.rb
@@ -18,7 +18,7 @@ module Buffet
         end
       end.parse!(args)
 
-      specs = Buffet.extract_specs_from(opts.empty? ? 'spec' : opts)
+      specs = !opts.empty? ? Buffet.extract_specs_from(opts) : %w(spec)
 
       runner = Runner.new
       runner.run specs

--- a/lib/buffet/master.rb
+++ b/lib/buffet/master.rb
@@ -71,13 +71,13 @@ module Buffet
     end
 
     def example_pending slave_name, details
-     @lock.synchronize do
-       @stats[:examples] += 1
-       @stats[:pending] += 1
-       @slaves_stats[slave_name][:pending] += 1
-     end
+      @lock.synchronize do
+        @stats[:examples] += 1
+        @stats[:pending] += 1
+        @slaves_stats[slave_name][:pending] += 1
+      end
 
-     @listener.example_pending
+      @listener.example_pending
     end
 
     private
@@ -118,8 +118,7 @@ module Buffet
 
     def run_slave slave
       time = Benchmark.measure do
-      slave.execute_in_project(
-        ".buffet/buffet-worker #{server_uri} #{slave.user_at_host} #{Settings.framework}")
+        slave.execute_in_project(".buffet/buffet-worker #{server_uri} #{slave.user_at_host} #{Settings.framework}")
       end.real
       @lock.synchronize { @slaves_stats[slave.name][:test_time] = time }
 

--- a/lib/buffet/settings.rb
+++ b/lib/buffet/settings.rb
@@ -30,6 +30,10 @@ module Buffet
         @project ||= Project.new Dir.pwd
       end
 
+      def rvm_ruby_string
+        self['rvm_ruby_string']
+      end
+
       def framework
         self['framework'].upcase || 'RSPEC1'
       end

--- a/lib/buffet/slave.rb
+++ b/lib/buffet/slave.rb
@@ -35,7 +35,7 @@ module Buffet
     end
 
     def user_at_host
-      "#{@user}@#{@host}"
+      @user ? "#{@user}@#{@host}" : @host
     end
 
     private

--- a/lib/buffet/slave.rb
+++ b/lib/buffet/slave.rb
@@ -21,7 +21,9 @@ module Buffet
     end
 
     def execute_in_project command
-      execute "cd #{@project.directory_on_slave} && #{command}"
+      command = "cd #{@project.directory_on_slave} && #{command}"
+      command = "rvm_path=$HOME/.rvm && $HOME/.rvm/bin/rvm-shell #{Settings.rvm_ruby_string} -c \"#{command}\"" if Settings.rvm_ruby_string
+      execute command
     end
 
     def execute command

--- a/support/buffet-worker
+++ b/support/buffet-worker
@@ -42,11 +42,22 @@ else
 
   RSpec::Core::Formatters::AugmentedTextFormatter.configure buffet_server, slave_name
 
-  while file = buffet_server.next_file_for(slave_name)
-    RSpec::Core::CommandLine.new(
-      ['--format', 'RSpec::Core::Formatters::AugmentedTextFormatter', file]
-    ).run($stderr, $stdout)
+  RSpec.configure do |config|
+    config.error_stream = $stderr
+    config.output_stream = $stdout
+    config.formatter = RSpec::Core::Formatters::AugmentedTextFormatter
+  end
 
-    RSpec.world.reset
+  RSpec.configuration.reporter.report(-1) do |reporter|
+    RSpec.configuration.run_hook(:before, :suite)
+    begin
+      while (file = buffet_server.next_file_for(slave_name))
+        load File.expand_path(file)
+        RSpec.world.example_groups.map { |g| g.run(reporter) }.all? ? 0 : 1
+        RSpec.world.example_groups.clear
+      end
+    ensure
+      RSpec.configuration.run_hook(:after, :suite)
+    end
   end
 end

--- a/support/buffet-worker
+++ b/support/buffet-worker
@@ -48,6 +48,8 @@ else
     config.formatter = RSpec::Core::Formatters::AugmentedTextFormatter
   end
 
+  require RSpec::Core::RubyProject.root.join("spec", "spec_helper").to_s if RSpec::Core::RubyProject.root.join("spec", "spec_helper.rb").exist?
+
   RSpec.configuration.reporter.report(-1) do |reporter|
     RSpec.configuration.run_hook(:before, :suite)
     begin

--- a/support/buffet-worker
+++ b/support/buffet-worker
@@ -19,7 +19,7 @@ FileUtils.mkdir_p('./tmp')
 if framework == 'RSPEC1'
   require 'spec'
   require 'spec/runner/command_line'
-  require File.dirname(__FILE__) + '/rspec1_formatter.rb'
+  require File.expand_path(File.join(File.dirname(__FILE__), 'rspec1_formatter'))
 
   Spec::Runner::Formatter::AugmentedTextFormatter.configure buffet_server, slave_name
 
@@ -38,7 +38,7 @@ if framework == 'RSPEC1'
   end
 else
   require 'rspec'
-  require File.dirname(__FILE__) + '/rspec2_formatter.rb'
+  require File.expand_path(File.join(File.dirname(__FILE__), 'rspec2_formatter'))
 
   RSpec::Core::Formatters::AugmentedTextFormatter.configure buffet_server, slave_name
 


### PR DESCRIPTION
It fails to extract options from empty command line arguments to run specs in spec folder by default
